### PR TITLE
Add output to finetuning prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ We used the following prompts for fine-tuning the Alpaca model:
  {input}
  
  ### Response:
+ {output}
  ```
 - for examples with an empty input field:
  ```
@@ -60,6 +61,7 @@ We used the following prompts for fine-tuning the Alpaca model:
  {instruction}
  
  ### Response:
+ {output}
  ```
 
 ## Data Generation Process


### PR DESCRIPTION
This PR adds the output to the fine-tuning prompt, which is presumably needed to train the model.

A question I have is: did you include the ` Below is an instruction that describes a task. Write a response that appropriately completes the request.` in every example or is that just for inference? Naively I would have guessed including it in training would make the model memorize this prompt, but perhaps that's actually useful in the end :)