### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ rouge_score
 fire
 openai
 transformers>=4.26.1
-torch
+torch>=1.13.1
 sentencepiece
 tokenizers==0.12.1
 wandb


### PR DESCRIPTION
I got this error
```bash
python3.10/site-packages/transformers-4.27.0.dev0-py3.10.egg/transformers/trainer.py", line 1460, in _wrap_model
    self.model = model = FSDP(
TypeError: FullyShardedDataParallel.__init__() got an unexpected keyword argument 'forward_prefetch'
```

[torch1.12](https://pytorch.org/docs/1.12/search.html?q=forward_prefetch&check_keywords=yes&area=default) does not support `forward_prefetch` .

So I switch torch to 1.13.1
