### PR TITLE
transformers version fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy
 rouge_score
 fire
 openai
-transformers>=4.26.1
+git+https://github.com/zphang/transformers.git@llama_push
 torch
 sentencepiece
 tokenizers==0.12.1


### PR DESCRIPTION
As mentioned in the repo, Hugging Face's transformers library by installing from a particular fork (i.e. this https://github.com/huggingface/transformers/pull/21955 to be merged).

So updating requirements.txt to install that version of transformers directly.