### PR TITLE
Something wrong with label ids

### DIFF
--- a/train.py
+++ b/train.py
@@ -120,7 +120,7 @@ def preprocess(
     input_ids = examples_tokenized["input_ids"]
     labels = copy.deepcopy(input_ids)
     for label, source_len in zip(labels, sources_tokenized["input_ids_lens"]):
-        label[:source_len]-1 = IGNORE_INDEX
+        label[:source_len-1] = IGNORE_INDEX
     return dict(input_ids=input_ids, labels=labels)
 
 

--- a/train.py
+++ b/train.py
@@ -32,12 +32,12 @@ PROMPT_DICT = {
     "prompt_input": (
         "Below is an instruction that describes a task, paired with an input that provides further context. "
         "Write a response that appropriately completes the request.\n\n"
-        "### Instruction:\n{instruction}\n\n### Input:\n{input}\n\n### Response:"
+        "### Instruction:\n{instruction}\n\n### Input:\n{input}\n\n### Response:\n"
     ),
     "prompt_no_input": (
         "Below is an instruction that describes a task. "
         "Write a response that appropriately completes the request.\n\n"
-        "### Instruction:\n{instruction}\n\n### Response:"
+        "### Instruction:\n{instruction}\n\n### Response:\n"
     ),
 }
 
@@ -120,7 +120,7 @@ def preprocess(
     input_ids = examples_tokenized["input_ids"]
     labels = copy.deepcopy(input_ids)
     for label, source_len in zip(labels, sources_tokenized["input_ids_lens"]):
-        label[:source_len] = IGNORE_INDEX
+        label[:source_len]-1 = IGNORE_INDEX
     return dict(input_ids=input_ids, labels=labels)
 
 


### PR DESCRIPTION
The prefix label id is made -100, as `source_len` counts an extra `eos` token, see below code. Subtracting 1 from `source_len` is necessary. https://github.com/tatsu-lab/stanford_alpaca/blob/65512697dc67779a6e53c267488aba0ec4d7c02a/train.py#L123
Also add an extra `\n` at the end of prompt input to prevent merged words between input and output texts.