### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 rouge_score
 fire
-openai
+openai==0.28.0
 transformers>=4.28.1
 torch
 sentencepiece


### PR DESCRIPTION
openai>=1.0 is incompatible when running weight_diff.py

openai==0.28.0 is ok.

This solved #303 

@lxuechen 